### PR TITLE
Cuda variant

### DIFF
--- a/buildscripts/set_python_path_for_bazelrc.sh
+++ b/buildscripts/set_python_path_for_bazelrc.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# *****************************************************************
+# (C) Copyright IBM Corp. 2021. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************
+set -ex
+
+# Set python path variables from conda build environment
+BAZEL_RC_DIR=$1
+
+cat >> $BAZEL_RC_DIR/.bazelrc << EOF
+build --action_env PYTHON_BIN_PATH="$PYTHON"
+build --action_env PYTHON_LIB_PATH="$SP_DIR"
+build --python_path="$PYTHON"
+EOF

--- a/buildscripts/set_tf_addons_for_bazelrc.sh
+++ b/buildscripts/set_tf_addons_for_bazelrc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# *****************************************************************
+# (C) Copyright IBM Corp. 2021. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************
+set -ex
+
+# Set needed variables for conda build environment
+BAZEL_RC_DIR=$1
+
+cat >> $BAZEL_RC_DIR/.bazelrc << EOF
+build --action_env GCC_HOST_COMPILER_PATH="${CC}"
+EOF

--- a/recipe/0001-Fix-build-on-ppc.patch
+++ b/recipe/0001-Fix-build-on-ppc.patch
@@ -1,33 +1,49 @@
-From c92c7f04f6e7cc2f7adc4ec4557c255a8e26ade3 Mon Sep 17 00:00:00 2001
+From ffc2286cc96a5d0bb5e914cd815a5f1d5d97a651 Mon Sep 17 00:00:00 2001
 From: Nishidha Panpaliya <npanpa23@in.ibm.com>
-Date: Wed, 31 Mar 2021 08:58:25 +0000
-Subject: [PATCH] Fix build on ppc
+Date: Thu, 1 Apr 2021 13:25:39 +0000
+Subject: [PATCH] Fixed build on ppc
 
 ---
- configure.py | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
+ configure.py | 22 +++++++++++++++++++++-
+ 1 file changed, 21 insertions(+), 1 deletion(-)
 
 diff --git a/configure.py b/configure.py
-index 4772a55..826a78d 100644
+index 4772a55..88d21a7 100644
 --- a/configure.py
 +++ b/configure.py
-@@ -48,6 +48,10 @@ def is_linux():
-     return platform.system() == "Linux"
- 
- 
-+def is_ppc64le():
-+    return os.uname()[4] == "ppc64le"
-+
-+
- def is_raspi_arm():
+@@ -52,6 +52,26 @@ def is_raspi_arm():
      return os.uname()[4] == "armv7l"
  
-@@ -118,7 +122,7 @@ def create_build_configuration():
+ 
++def is_linux_ppc64le():
++    return is_linux() and platform.machine() == "ppc64le"
++
++
++def is_linux_x86_64():
++    return is_linux() and platform.machine() == "x86_64"
++
++
++def is_linux_arm():
++    return is_linux() and platform.machine() == "arm"
++
++
++def is_linux_aarch64():
++    return is_linux() and platform.machine() == "aarch64"
++
++
++def is_linux_s390x():
++    return is_linux() and platform.machine() == "s390x"
++
++
+ def get_tf_header_dir():
+     import tensorflow as tf
+ 
+@@ -118,7 +138,7 @@ def create_build_configuration():
          write("build:windows --host_copt=/experimental:preprocessor")
          write("build:windows --copt=/arch=AVX")
  
 -    if is_macos() or is_linux():
-+    if is_macos() or (is_linux() and not is_ppc64le()):
++    if is_macos() or is_linux_x86_64():
          write("build --copt=-mavx")
  
      if os.getenv("TF_NEED_CUDA", "0") == "1":

--- a/recipe/build-addons.sh
+++ b/recipe/build-addons.sh
@@ -20,7 +20,19 @@ set -vex
 bazel clean --expunge
 bazel shutdown
 
+if [[ $build_type == "cuda" ]];
+then 
+  export TF_NEED_CUDA=1
+  export TF_CUDA_VERSION="${cudatoolkit%.*}"
+  export TF_CUDNN_VERSION="${cudnn%.*}"
+  export CUDA_TOOLKIT_PATH=$CUDA_HOME,$PREFIX,"/usr/include"
+  export CUDNN_INSTALL_PATH=$PREFIX
+fi
 python ./configure.py
+
+SCRIPT_DIR=$RECIPE_DIR/../buildscripts
+$SCRIPT_DIR/set_python_path_for_bazelrc.sh $SRC_DIR
+$SCRIPT_DIR/set_tf_addons_for_bazelrc.sh $SRC_DIR
 
 bazel build --enable_runfiles build_pip_pkg
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ outputs:
     build:
       string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}{{ cudatoolkit | replace(".*", "") }} #[build_type == 'cuda']
       string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}  #[build_type == 'cpu']
- {% if build_type == 'cuda' %}
+{% if build_type == 'cuda' %}
       script_env:
         - CUDA_HOME
 {% endif %}
@@ -56,19 +56,19 @@ outputs:
         - git >={{ git }}
       host:
         - python  {{ python }}
-      {% if build_type == 'cuda' %}
-￼       - cudatoolkit {{ cudatoolkit }}
-￼       - cudnn {{ cudnn }}
-￼       - nccl {{ nccl }}
- ￼    {% endif %}
+{% if build_type == 'cuda' %}
+        - cudatoolkit {{ cudatoolkit }}
+        - cudnn {{ cudnn }}
+        - nccl {{ nccl }}
+{% endif %}
         - tensorflow-base {{ tensorflow }}
       run:
         - python  {{ python }}
-      {% if build_type == 'cuda' %}
-￼       - cudatoolkit {{ cudatoolkit }}
-￼       - cudnn {{ cudnn }}
-￼       - nccl {{ nccl }}
- ￼    {% endif %}
+{% if build_type == 'cuda' %}
+        - cudatoolkit {{ cudatoolkit }}
+        - cudnn {{ cudnn }}
+        - nccl {{ nccl }}
+{% endif %}
         - tensorflow-base {{ tensorflow }}
       run_constrained:
         - tensorflow-addons-proc * {{ build_ext }}
@@ -84,8 +84,8 @@ outputs:
          TensorFlow Addons is a repository of contributions that conform to well-established API patterns,
          but implements new functionality not available in core.
 
-    test:
-      imports:
+#    test:
+#      imports:
         #- tensorflow-addons
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set version = "0.12.1" %}
 {% set build_ext_version = version %}
-{% set build_ext = "cuda" if build_type == 'cuda' else "cpu" %}
 {% set proc_build_number = "1" %}
 
 package:
@@ -23,7 +22,7 @@ outputs:
     version: {{ build_ext_version }}
     build:
       number: {{ proc_build_number }}
-      string: {{ build_ext }}
+      string: {{ build_type }}
     test:
       commands:
         - exit 0
@@ -38,8 +37,8 @@ outputs:
     script: build-addons.sh
     version: {{ version }}
     build:
-      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}{{ cudatoolkit | replace(".*", "") }} #[build_type == 'cuda']
-      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}  #[build_type == 'cpu']
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_type }}{{ cudatoolkit | replace(".*", "") }} #[build_type == 'cuda']
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_type }}  #[build_type == 'cpu']
 {% if build_type == 'cuda' %}
       script_env:
         - CUDA_HOME
@@ -60,19 +59,21 @@ outputs:
         - cudatoolkit {{ cudatoolkit }}
         - cudnn {{ cudnn }}
         - nccl {{ nccl }}
+        - tensorflow {{ tensorflow }}
 {% endif %}
-        - tensorflow-base {{ tensorflow }}
+        - tensorflow-cpu {{ tensorflow }} #[build_type == 'cpu']
       run:
         - python  {{ python }}
 {% if build_type == 'cuda' %}
         - cudatoolkit {{ cudatoolkit }}
         - cudnn {{ cudnn }}
         - nccl {{ nccl }}
+        - tensorflow {{ tensorflow }}
 {% endif %}
-        - tensorflow-base {{ tensorflow }}
+        - tensorflow-cpu {{ tensorflow }} #[build_type == 'cpu']
         - typeguard
       run_constrained:
-        - tensorflow-addons-proc * {{ build_ext }}
+        - tensorflow-addons-proc * {{ build_type }}
 
 
     about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,7 @@ outputs:
         - nccl {{ nccl }}
 {% endif %}
         - tensorflow-base {{ tensorflow }}
+        - typeguard
       run_constrained:
         - tensorflow-addons-proc * {{ build_ext }}
 
@@ -84,9 +85,9 @@ outputs:
          TensorFlow Addons is a repository of contributions that conform to well-established API patterns,
          but implements new functionality not available in core.
 
-#    test:
-#      imports:
-        #- tensorflow-addons
+    test:
+      imports:
+        - tensorflow_addons
 
 about:
   home: https://www.tensorflow.org/addons/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,10 @@
 {% set version = "0.12.1" %}
+{% set build_ext_version = version %}
+{% set build_ext = "cuda" if build_type == 'cuda' else "cpu" %}
+{% set proc_build_number = "1" %}
 
 package:
-  name: tensorflow-addons
+  name: tensorflow-addons-ext
   version: {{ version }}
 
 source:
@@ -11,21 +14,79 @@ source:
     - 0001-Fix-build-on-ppc.patch  #[ppc64le] 
 
 build:
-  number: 1
-  string: py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
-  
-requirements:
-  build:
-    - {{ compiler('c') }}
-    - {{ compiler('cxx') }}
-    - bazel {{ bazel }}
-    - git >={{ git }}
-  host:
-    - python  {{ python }}
-    - tensorflow-base {{ tensorflow }}
-  run:
-    - python  {{ python }}
-    - tensorflow-base {{ tensorflow }}
+  number: 2
+  run_exports:
+    - {{ pin_subpackage("tensorflow-addons", max_pin="x.x.x") }}
+
+outputs:
+  - name: tensorflow-addons-proc
+    version: {{ build_ext_version }}
+    build:
+      number: {{ proc_build_number }}
+      string: {{ build_ext }}
+    test:
+      commands:
+        - exit 0
+    about:
+      home: https://www.tensorflow.org/addons/
+      license: Apache-2.0
+      license_family: Apache
+      license_file: {{ SRC_DIR }}/LICENSE
+      summary: "A meta-package to select TensorFlow addons build variant"
+
+  - name: tensorflow-addons
+    script: build-addons.sh
+    version: {{ version }}
+    build:
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}{{ cudatoolkit | replace(".*", "") }} #[build_type == 'cuda']
+      string: py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}_{{ build_ext }}  #[build_type == 'cpu']
+ {% if build_type == 'cuda' %}
+      script_env:
+        - CUDA_HOME
+{% endif %}
+      run_exports:
+        - {{ pin_subpackage("tensorflow-addons", max_pin="x.x.x") }}
+      track_features:
+        {{ "- tensorflow-addons-cuda" if build_type == 'cuda' else "" }} 
+    requirements:
+      build:
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+        - bazel {{ bazel }}
+        - git >={{ git }}
+      host:
+        - python  {{ python }}
+      {% if build_type == 'cuda' %}
+￼       - cudatoolkit {{ cudatoolkit }}
+￼       - cudnn {{ cudnn }}
+￼       - nccl {{ nccl }}
+ ￼    {% endif %}
+        - tensorflow-base {{ tensorflow }}
+      run:
+        - python  {{ python }}
+      {% if build_type == 'cuda' %}
+￼       - cudatoolkit {{ cudatoolkit }}
+￼       - cudnn {{ cudnn }}
+￼       - nccl {{ nccl }}
+ ￼    {% endif %}
+        - tensorflow-base {{ tensorflow }}
+      run_constrained:
+        - tensorflow-addons-proc * {{ build_ext }}
+
+
+    about:
+      home: https://www.tensorflow.org/addons/
+      license: Apache-2.0
+      license_family: Apache
+      license_file: {{ SRC_DIR }}/LICENSE
+      summary: "A library that implements new functionality not available in core TensorFlow."
+      description: |
+         TensorFlow Addons is a repository of contributions that conform to well-established API patterns,
+         but implements new functionality not available in core.
+
+    test:
+      imports:
+        #- tensorflow-addons
 
 about:
   home: https://www.tensorflow.org/addons/


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any [tests](https://github.com/open-ce/open-ce/blob/main/tests/) to validate this change?  

## Description

This PR adds the CUDA variant for Tensorflow Addons. This uses the new style selector meta package which includes the build variant in the package string instead of the name. The resulting packages are:

```
tensorflow-addons-0.12.1-py37hd06ef9e_2_cuda10.2.tar.bz2
tensorflow-addons-0.12.1-py37hd06ef9e_2_cpu.tar.bz2
tensorflow-addons-proc-0.12.1-cuda.tar.bz2
tensorflow-addons-proc-0.12.1-cpu.tar.bz2
```

Fixes #7 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
